### PR TITLE
feat: Docker Image Tracking

### DIFF
--- a/.github/renovate.jsonc
+++ b/.github/renovate.jsonc
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "branchPrefix": "chore/",
+    "semanticCommits": "enabled",
+    "reviewers": [
+        "fanshan"
+    ],
+    "minimumReleaseAge": "2 days",
+    // Default settings if not specified above.
+    "extends": [
+      "config:recommended"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ docker run -d -p 8080:8080 -p 80:80 -p 8081:8081 \
   -v /var/run/docker.sock:/var/run/docker.sock \
   saashup/traefik
 ```
+
+## Renovate
+
+Renovate is used to automated dependency update through the creation of pull requests. Its configuration file can be found in the `.github/renovate.jsonc`. While mostly using the default configurations some customization will be explained bellow:
+
+- `branchPrefix`: `chore/` instead of `renovate/`. This change is to better adhere to Conventional Branch naming conventions 
+- `semanticCommits`: `enabled` instead of `auto`. This force the use of Conventional Commits naming conventions 
+- `reviewers`: This tells who are to be assigned to review renovate PR.
+- `minimumReleaseAge`: `2 days` instead of `null`. This force Renovate to wait for 2 days after a new tag release before creating an upgrade PR, this mechanism partially mitigate supply chains attacks.
+
+Default which were not defined here can be found on [the official renovate documentation](https://docs.renovatebot.com/configuration-options/)


### PR DESCRIPTION
# Docker Image Tracking

This PR fix issues #6 by introducing Renovate to the repository.

## Features

- Automated PRs with oneline changes
- 2 days update availability before PR creations (to metigate supply chains risks linked to compromised upstream)
- Conventionnal Commits and Branching
- Automatically Ask specified users for review (This was set to most asked reviewer in previous PRs)
- Automatically retrive the changelog between the installed and the proposed version

## POC

A proof of concept (using the Mend Github app) can be found [here](https://github.com/Torreip/traefik-saashup/pull/2)

<img width="879" height="822" alt="image" src="https://github.com/user-attachments/assets/0a954149-7f99-4579-91b3-cfb3c29c9e9d" />

## Enabling

While this PR introduce the config file needed for renovate to work. It does not provide a renovate instance. To achieve this either the hosted Mend Renovate app  or a selfhosted instance can be used. for more information please reffer to [the official documentation](https://docs.renovatebot.com/getting-started/running/)

### Mend Github app

If you decide to go with the mend Github app the following settings are to be applied for the best results 

<img width="1203" height="765" alt="image" src="https://github.com/user-attachments/assets/c166ff50-050c-49eb-8a97-8a44596e5e0f" />

## 🎯 Acceptance Criteria

- [X] A new Traefik release triggers an automated PR targeting the `Dockerfile`
- [X] The PR updates only the version tag in the `FROM` instruction
- [X] The automation is documented (in README or a dedicated doc)